### PR TITLE
Add Netlify deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 # React Static Boilerplate
 
 A boilerplate for building static sites with [React][] and [React Router][]
+<!-- Markdown snippet -->
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/iansinnott/react-static-boilerplate)
 
 **Quick Start:**
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "build"


### PR DESCRIPTION
I opened this PR to add a Netlify example and one click deploy button. The netlify.toml file just populates the build command bundle output location.

test out the button here:

<!-- Markdown snippet -->
[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/react-static-boilerplate-1)

Let me know if you have any questions. Also if you have interest we offer a [free plan](https://www.netlify.com/open-source/) at Netlify for all open source projects, check out the details here if you are interested in using it for static-boilerplate examples.
